### PR TITLE
add tests on resume validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "json-resume"
+name = "json-resume-serde"
 version = "0.1.0"
 dependencies = [
  "email_address",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "json-resume"
+name = "json-resume-serde"
 version = "0.1.0"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,52 @@
 # json-resume
 
-A Rust implementation of the [JSON Resume schema](https://github.com/jsonresume/resume-schema/blob/master/schema.json) with Serde support for serialization and deserialization.
+A Rust implementation of the [JSON Resume schema](https://github.com/jsonresume/resume-schema/blob/master/schema.json) with Serde and Validate support for serialization and deserialization.
+
+## Usage
+
+### From Serialized JSON
+```rs
+use serde_valid::Validate;
+
+#[axum::debug_handler]
+async fn post(Json(resume): Json<json_resume::Resume>) -> Result<Json<Resume>, ResumeError> {
+
+   let result = resume.validate()
+
+   // do stuff
+
+   Ok(Json(resume))
+}
+```
+
+### Build manually
+```rs
+use serde_valid::Validate;
+
+    let resume = json_resume::Resume {
+        basics: Some(json_resume::Basics {
+            //...
+        }),
+        work: vec![
+            json_resume::Work {
+                // ...
+            }
+        ],
+        volunteer: vec![],
+        education: vec![],
+        awards: vec![],
+        certificates: vec![],
+        publications: vec![],
+        skills: vec![],
+        languages: vec![],
+        interests: vec![],
+        references: vec![],
+        projects: vec![],
+    };
+
+    resume.validate().unwrap();
+```
+
 
 ## License
 

--- a/src/resume.rs
+++ b/src/resume.rs
@@ -31,16 +31,103 @@ pub use work::Work;
 
 #[derive(Debug, Serialize, Deserialize, Validate)]
 pub struct Resume {
-    pub basics: Basics,
+    #[validate]
+    pub basics: Option<Basics>,
+    #[validate]
     pub work: Vec<Work>,
+    #[validate]
     pub volunteer: Vec<Volunteer>,
+    #[validate]
     pub education: Vec<Education>,
+    #[validate]
     pub awards: Vec<Award>,
+    #[validate]
     pub certificates: Vec<Certificate>,
+    #[validate]
     pub publications: Vec<Publication>,
+    #[validate]
     pub skills: Vec<Skill>,
+    #[validate]
     pub languages: Vec<Language>,
+    #[validate]
     pub interests: Vec<Interest>,
+    #[validate]
     pub references: Vec<Reference>,
+    #[validate]
     pub projects: Vec<Project>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resume::{Basics, Resume};
+
+    #[test]
+    fn test_resume_validation() {
+        let basics = Basics {
+            name: Some("John Doe".to_string()),
+            label: Some("Programmer".to_string()),
+            image: Some("https://example.com/image.jpg".to_string()),
+            email: Some("john.doe@example.com".to_string()),
+            phone: Some("+1234567890".to_string()),
+            url: Some("https://johndoe.com".to_string()),
+            summary: Some("A passionate developer.".to_string()),
+            location: None,
+            profiles: vec![],
+        };
+
+        let resume = Resume {
+            basics: Some(basics),
+            work: vec![],
+            volunteer: vec![],
+            education: vec![],
+            awards: vec![],
+            certificates: vec![],
+            publications: vec![],
+            skills: vec![],
+            languages: vec![],
+            interests: vec![],
+            references: vec![],
+            projects: vec![],
+        };
+
+        // Validate the resume. This will return Result<(), ValidationErrors>
+        let result = resume.validate();
+        assert!(
+            result.is_ok(),
+            "Resume validation failed: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_resume_validation_invalid() {
+        let resume = Resume {
+            basics: Some(Basics {
+                name: Some("John Doe".to_string()),
+                label: Some("Programmer".to_string()),
+                image: Some("https://example.com/image.jpg".to_string()),
+                email: Some("not-an-email".to_string()),
+                phone: Some("+1234567890".to_string()),
+                url: Some("https://johndoe.com".to_string()),
+                summary: Some("A passionate developer.".to_string()),
+                location: None,
+                profiles: vec![],
+            }),
+            work: vec![],
+            volunteer: vec![],
+            education: vec![],
+            awards: vec![],
+            certificates: vec![],
+            publications: vec![],
+            skills: vec![],
+            languages: vec![],
+            interests: vec![],
+            references: vec![],
+            projects: vec![],
+        };
+
+        let result = resume.validate();
+        assert!(result.is_err(), "Resume validation should fail");
+    }
 }

--- a/src/resume/interest.rs
+++ b/src/resume/interest.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Validate)]
 pub struct Interest {
     pub name: Option<String>,
     pub keywords: Vec<String>,

--- a/src/resume/language.rs
+++ b/src/resume/language.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Validate)]
 pub struct Language {
     pub language: Option<String>,
     pub fluency: Option<String>,

--- a/src/resume/reference.rs
+++ b/src/resume/reference.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Validate)]
 pub struct Reference {
     pub name: Option<String>,
     pub reference: Option<String>,

--- a/src/resume/skill.rs
+++ b/src/resume/skill.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Validate)]
 pub struct Skill {
     pub name: Option<String>,
     pub level: Option<String>,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation support for resume fields, including interests, languages, references, and skills.
  * Enhanced the Resume structure to support field validation and made the "basics" section optional.

* **Documentation**
  * Expanded the README with detailed usage instructions and examples for validating JSON Resume data in Rust.

* **Tests**
  * Introduced tests to verify correct validation behavior for valid and invalid resume data.

* **Chores**
  * Updated the package name to "json-resume-serde" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->